### PR TITLE
Removed "sort()" directive on POST paramters API calls.

### DIFF
--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -26,7 +26,7 @@ module.exports = (function() {
             }
 
             // Sort parameters alphabetically and convert to `arg1=foo&arg2=bar`
-            paramString = Object.keys(parameters).sort().map(function(param){
+            paramString = Object.keys(parameters).map(function(param){
                 return encodeURIComponent(param) + '=' + encodeURIComponent(parameters[param]);
             }).join('&');
 


### PR DESCRIPTION
Some private directives like "buy" and "sell" didn't sign requests correctly. ("Invalid key/secret pair" error message).
Removing parameters "sort()" before signing seems to solve the problem. Parameter order doesn't seem to be important on server side (I didn't re-tested all features btw), but it does for signature.