### PR TITLE
Add returnTradeHistory for public data

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,35 @@ Example response:
   {"asks":[[0.00007600,1164],[0.00007620,1300], ... "bids":[[0.00006901,200],[0.00006900,408], ... }
 
 
+### returnTradeHistory(currencyA, currencyB, [start, end,] callback)
+
+Returns the past 200 trades for a given market, or up to 50,000 trades between a range specified in UNIX timestamps by the "start" and "end" parameters.
+
+  poloniex.returnTradeHistory('BTC', 'ETH', function(err, data) {
+    if (err){
+      // handle error
+    }
+
+    console.log(data);
+  });
+
+Example response:
+
+  [ { globalTradeID: 394411584,
+      tradeID: 45193152,
+      date: '2018-10-19 18:31:21',
+      type: 'sell',
+      rate: '0.03136000',
+      amount: '4.14926279',
+      total: '0.13012088' },
+    { globalTradeID: 394411489,
+      tradeID: 45193150,
+      date: '2018-10-19 18:30:58',
+      type: 'sell',
+      rate: '0.03135505',
+      amount: '0.05757062',
+      total: '0.00180512' },
+
 ### returnChartData(currencyA, currencyB, period, start, end, callback)
 
 Returns candlestick chart data. Candlestick "period" is one of 300, 900, 1800, 7200, 14400, or 86400 seconds. "Start" and "end" are given in UNIX timestamp format and used to specify the date range for the data returned.

--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -7,7 +7,7 @@ module.exports = (function() {
     nonce   = require('nonce')();
 
   // Constants
-  var version     = '0.0.9',
+  var version     = '0.0.10',
     PUBLIC_API_URL  = 'https://poloniex.com/public',
     PRIVATE_API_URL = 'https://poloniex.com/tradingApi',
     USER_AGENT    = 'poloniex.js ' + version;
@@ -23,6 +23,8 @@ module.exports = (function() {
     return currencyA + '_' + currencyB;
   }
 
+  var authenticated = false;
+
   // Constructor
   function Poloniex(key, secret) {
     // Generate headers signed by this user's key and secret.
@@ -33,6 +35,8 @@ module.exports = (function() {
       if (!key || !secret) {
         throw 'Poloniex: Error. API key and secret required';
       }
+
+      authenticated = true;
 
       // Convert to `arg1=foo&arg2=bar`
       paramString = Object.keys(parameters).map(function(param) {
@@ -244,7 +248,10 @@ module.exports = (function() {
         end: end
       };
 
-      return this._private('returnTradeHistory', parameters, callback);
+      if (authenticated)
+        return this._private('returnTradeHistory', parameters, callback);
+      else
+        return this._public('returnTradeHistory', parameters, callback);
     },
 
     returnOrderTrades: function(orderNumber, callback) {


### PR DESCRIPTION
returnTradeHistory is both a private and a public command. This adds support for the public version. To access, create a `Poloniex()` object without key / secret.