### PR TITLE
Allow returning all currencies

### DIFF
--- a/lib/poloniex.js
+++ b/lib/poloniex.js
@@ -225,7 +225,6 @@ module.exports = (function() {
         callback = currencyB;
         currencyB = null;
       }
-
       else {
         currencyPair = joinCurrencies(currencyA, currencyB);
       }
@@ -238,17 +237,26 @@ module.exports = (function() {
     },
 
     returnTradeHistory: function(currencyA, currencyB, start, end, callback) {
-      if(arguments.length < 5){
-        callback = start;
-        start = Date.now() / 1000 - 60 * 60;
-        end = Date.now() / 1000 + 60 * 60; // Some buffer in case of client/server time out of sync.
+      var parameters;
+      if (currencyA === 'all') { // shift all arguments by 1
+        callback = end;
+        end = start;
+        start = currencyB;
+        parameters = { currencyPair: 'all' };
+      }
+      else {
+        parameters = { currencyPair: joinCurrencies(currencyA, currencyB) };
       }
 
-      var parameters = {
-        currencyPair: joinCurrencies(currencyA, currencyB),
-        start: start,
-        end: end
-      };
+      if (typeof start === 'function') {
+        callback = start;
+        parameters.start = Date.now() / 1000 - 60 * 60;
+        parameters.end = Date.now() / 1000 + 60 * 60; // Some buffer in case of client/server time out of sync
+      }
+      else {
+        parameters.start = start;
+        parameters.end = end;
+      }
 
       if (authenticated)
         return this._private('returnTradeHistory', parameters, callback);


### PR DESCRIPTION
returnTradeHistory in the private API context can now be called in three different ways
```
poloniex.returnTradeHistory('all', callback)
poloniex.returnTradeHistory(currencyA, currencyB, callback)
poloniex.returnTradeHistory(currencyA, currencyB, start, end, callback)
```
